### PR TITLE
Apply all diffs returned from API

### DIFF
--- a/src/server/openai.ts
+++ b/src/server/openai.ts
@@ -30,31 +30,31 @@ const containsDiff = (message: string) => {
 };
 
 const applyDiff = (code: string, diff: string) => {
-  const before = /<<<<<<< ORIGINAL\n(.*?)=======/gs.exec(diff);
-  const after = /=======\n(.*?)>>>>>>> UPDATED/gs.exec(diff);
+  const regex = /<<<<<<< ORIGINAL\n(.*?)=======\n(.*?)>>>>>>> UPDATED/gs;
+
+  let match;
 
   // debugger;
-  if (before && after && before.length === after.length) {
-    before.forEach((b, i) => {
-      if (i === 0) return;
-      // Convert match to a regex. We need to do this because
-      // gpt returns the code with the tabs removed. The idea here is to
-      // convert newlines to \s+ so that we catch even if the indentation
-      // is different.
-      // TODO: Before we replace, we can also check how indented the code is
-      // and add the same indentation to the replacement.
-      let regex = escapeRegExp(b);
-      regex = regex.replaceAll(/\r?\n/g, "\\s+");
-      regex = regex.replaceAll(/\t/g, "");
+  while ((match = regex.exec(diff)) !== null) {
+    const [, before, after] = match;
 
-      // Create the regex
-      const replaceRegex = new RegExp(regex);
+    // Convert match to a regex. We need to do this because
+    // gpt returns the code with the tabs removed. The idea here is to
+    // convert newlines to \s+ so that we catch even if the indentation
+    // is different.
+    // TODO: Before we replace, we can also check how indented the code is
+    // and add the same indentation to the replacement.
+    let regex = escapeRegExp(before!);
+    regex = regex.replaceAll(/\r?\n/g, "\\s+");
+    regex = regex.replaceAll(/\t/g, "");
 
-      // console.log(`Replacing $$$${replaceRegex}$$$ with $$$${after[i]}$$$`);
-      // console.log(`Code before: ${code}`);
+    // Create the regex
+    const replaceRegex = new RegExp(regex);
 
-      code = code.replace(replaceRegex, after[i]!);
-    });
+    // console.log(`Replacing $$$${replaceRegex}$$$ with $$$${after}$$$`);
+    // console.log(`Code before: ${code}`);
+
+    code = code.replace(replaceRegex, after!);
   }
 
   return code;


### PR DESCRIPTION
Hello, first of all I'd like to thank you for making this project open-source!

While playing with the code generation I noticed that OpenAI API was returning more diffs than what was apparent. This was most evident in the "Features of a product" example prompt. I asked the AI to replace 4 placeholder features with "features that should describe being open source, super cheap, fast and user-friendly". Each time I would see only the first feature being changed, but in the logs I could see that there was a full diff for all 4 features.

The code looked fine at first glance, it tried to iterate through all matches, but the devil is in the details. The `exec` method will return only one match per run on a particular RegExp object, as these objects are stateful if we use `g` flag. This PR adjusts the code to run the `exec` method until all matches have been processed. It also consolidates 2 regular expressions into one, this way we don't need to make sure that `before` and `after` have the same amount of matches.