### PR TITLE
Fork revisions and import from code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 # Database & Storage
 # -----------------------------------------------------------------------------
-DATABASE_URL="postgresql://postgres:@localhost:5432/rapidpages"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/rapidpages"
 
 # -----------------------------------------------------------------------------
 # App Related
@@ -32,7 +32,7 @@ SLACK_WEBHOOK_URL=
 # https://next-auth.js.org/configuration/options#secret
 # -----------------------------------------------------------------------------
 NEXTAUTH_SECRET=al2osAbJ+ati5apWKzgHE7v2JHp3Hjb1sBz88XSM2uU=
-NEXTAUTH_URL=http://app.localhost:3000
+NEXTAUTH_URL=http://localhost:3000
 
 # -----------------------------------------------------------------------------
 # Auth

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ git clone https://github.com/rapidpages/rapidpages.git && cd rapidpages
 
 Edit the `.env.example` file to ensure the following values are set:
 
+- `GITHUB_CLIENT_SECRET` & `GITHUB_CLIENT_ID`: you need to [create a GitHub oauth application](https://github.com/settings/applications/new) to be able to login. For `localhost` use `http://localhost:3000` and `http://localhost:3000/api/auth/callback/github` for Homepage and Authorization callback URL.
 - `OPENAI_API_KEY`: you need to get a key from [OpenAI](https://platform.openai.com/)
-- `GITHUB_CLIENT_SECRET` & `GITHUB_CLIENT_ID`: you need to create a GitHub oauth application to be able to login. Follow [this guide](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) from GitHub.
 
 #### Run Rapidpages on Host
+
 Create the database & run the application
 
 ```bash

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,11 @@ model User {
     components Component[]
 }
 
+enum ComponentVisibility {
+    PUBLIC
+    PRIVATE
+}
+
 model Component {
     id     String @id @default(cuid())
     code   String
@@ -62,6 +67,8 @@ model Component {
 
     author   User?   @relation(fields: [authorId], references: [id])
     authorId String?
+
+    visibility ComponentVisibility @default(PUBLIC)
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt

--- a/src/components/UserAuthForm.tsx
+++ b/src/components/UserAuthForm.tsx
@@ -3,10 +3,13 @@
 import * as React from "react";
 import { signIn } from "next-auth/react";
 import { cn } from "~/utils/utils";
+import { useRouter } from "next/router";
 
 type UserAuthFormProps = React.HTMLAttributes<HTMLDivElement>;
 
 export const UserAuthForm = ({ className, ...props }: UserAuthFormProps) => {
+  const router = useRouter();
+
   return (
     <div className={cn("mt-6 grid gap-6", className)} {...props}>
       {/* <button
@@ -131,7 +134,14 @@ export const UserAuthForm = ({ className, ...props }: UserAuthFormProps) => {
       <button
         type="button"
         className="inline-flex w-full items-center justify-center rounded-lg border bg-white px-5  text-center text-sm font-medium text-black hover:bg-slate-100 focus:outline-none focus:ring-4 focus:ring-[#24292F]/50 dark:hover:bg-[#050708]/30 dark:focus:ring-slate-500"
-        onClick={() => signIn("github", { callbackUrl: "/" })}
+        onClick={() =>
+          signIn("github", {
+            callbackUrl:
+              typeof router.query?.redirect === "string"
+                ? router.query.redirect
+                : "/",
+          })
+        }
       >
         <svg
           width="46px"

--- a/src/pages/new.tsx
+++ b/src/pages/new.tsx
@@ -172,6 +172,7 @@ const NewPage: NextPageWithLayout = () => {
               <button
                 type="submit"
                 className="ml-1 inline-flex items-center rounded-md bg-indigo-600 px-2 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                disabled={isGenerating}
               >
                 <PaperAirplaneIcon className="h-4 w-4"></PaperAirplaneIcon>
               </button>
@@ -206,6 +207,7 @@ const NewPage: NextPageWithLayout = () => {
                           e.preventDefault();
                           handleGenerateComponent(item.description);
                         }}
+                        disabled={isGenerating}
                       >
                         <span className="absolute inset-0" aria-hidden="true" />
                         {item.name}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -68,6 +68,8 @@ const SettingsPage: NextPageWithLayout = () => {
                         <Image
                           className="h-12 w-12 rounded-full"
                           src="/images/person.jpg"
+                          width={48}
+                          height={48}
                           alt=""
                         />
                       )}


### PR DESCRIPTION
This PR implements an endpoint (and the minor UI necessary) to fork a revision and optionally its ancestors. This can be used to create templates to clone/fork.

Additionally it adds an endpoint to import components from arbitrary code. The endpoint is not exposed via public tRPC api yet because it could be misused. 

Potentially you could expose this only to admins etc. to allow other applications of yours to create components programmatically.