### PR TITLE
Improve revisions access

### DIFF
--- a/src/pages/c/[index].tsx
+++ b/src/pages/c/[index].tsx
@@ -40,7 +40,9 @@ const ComponentPage: NextPageWithLayout<
                 className="flex h-full flex-col pr-3"
               >
                 <EditorTabs code={component.code} revisionId={lastRevisionId} />
-                {session && <Chat revisionId={lastRevisionId} />}
+                {session && session.user.id === component.authorId && (
+                  <Chat revisionId={lastRevisionId} />
+                )}
               </Panel>
             </PanelGroup>
           </div>

--- a/src/pages/r/[index].tsx
+++ b/src/pages/r/[index].tsx
@@ -40,7 +40,9 @@ const RevisionPage: NextPageWithLayout<
                 className="flex h-full flex-col pr-3"
               >
                 <EditorTabs code={code} revisionId={revisionId} />
-                {session && <Chat revisionId={revisionId} />}
+                {session && session.user.id === component.authorId && (
+                  <Chat revisionId={revisionId} />
+                )}
               </Panel>
             </PanelGroup>
           </div>

--- a/src/server/api/routers/component.ts
+++ b/src/server/api/routers/component.ts
@@ -171,8 +171,8 @@ export const componentRouter = createTRPCRouter({
 
       // Users can fork public revisions or, if private, their own.
       if (
-        component.visibility === ComponentVisibility.PRIVATE &&
-        component.authorId != userId
+        component.authorId != userId &&
+        component.visibility === ComponentVisibility.PRIVATE
       ) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -221,6 +221,17 @@ export const componentRouter = createTRPCRouter({
       });
 
       if (component) {
+        const userId = ctx.session?.user.id;
+
+        if (
+          component.authorId !== userId &&
+          component.visibility === ComponentVisibility.PRIVATE
+        ) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+          });
+        }
+
         return component;
       }
 
@@ -246,6 +257,17 @@ export const componentRouter = createTRPCRouter({
       });
 
       if (component) {
+        const userId = ctx.session?.user.id;
+
+        if (
+          component.authorId !== userId &&
+          component.visibility === ComponentVisibility.PRIVATE
+        ) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+          });
+        }
+
         return component;
       }
 


### PR DESCRIPTION
Up until now users could create revisions on other users' components.

With this PR we protect private and other users' revisions from being edited or (depending on their visibility) viewed.